### PR TITLE
Handle DuckDuckGo redirects 

### DIFF
--- a/plugins/Internet/plugin.py
+++ b/plugins/Internet/plugin.py
@@ -555,7 +555,8 @@ class Internet(callbacks.Plugin):
         except IndexError:
             irc.reply("Can't find what you are looking for.")
         else:
-            irc.reply("{} <{}>".format(result["title"], result["url"]))
+            irc.reply("DuckDuckGo({}): {} ({})".format(
+                text, ircutils.bold(result["title"]), result["url"]))
 
 Internet = internationalizeDocstring(Internet)
 

--- a/plugins/Internet/plugin.py
+++ b/plugins/Internet/plugin.py
@@ -555,7 +555,7 @@ class Internet(callbacks.Plugin):
         except IndexError:
             irc.reply("Can't find what you are looking for.")
         else:
-            irc.reply("DuckDuckGo({}): {} ({})".format(
+            irc.reply("DuckDuckGo ({}): {} <{}>".format(
                 text, ircutils.bold(result["title"]), result["url"]))
 
 Internet = internationalizeDocstring(Internet)

--- a/plugins/Internet/plugin.py
+++ b/plugins/Internet/plugin.py
@@ -554,8 +554,6 @@ class Internet(callbacks.Plugin):
             result = self._ddg(text)[0]
         except IndexError:
             irc.reply("Can't find what you are looking for.")
-        except Exception as e:
-            irc.error(e)
         else:
             irc.reply("{} <{}>".format(result["title"], result["url"]))
 

--- a/plugins/Internet/plugin.py
+++ b/plugins/Internet/plugin.py
@@ -536,8 +536,8 @@ class Internet(callbacks.Plugin):
         result = page.find("div", {"class": "result__body"})
         title = result.find("h2", {"class": "result__title"}).text.strip()
         try:
-            url = title.find("a").attrs["href"]
-            url = utils.web.urlunquote(url[url.rfind("=")+1:])
+            query = urlparse.urlparse(title.find("a").attrs["href"]).query
+            url = urlparse.parse_qs(query)["uddg"][0]
             description = result.find("a", {"class": "result__snippet"}).text
         except Exception:
             irc.reply("{}".format(title))   # Title will likely be a DuckDuckGo

--- a/plugins/Internet/plugin.py
+++ b/plugins/Internet/plugin.py
@@ -532,6 +532,9 @@ class Internet(callbacks.Plugin):
         page = BS(utils.web.getUrl(self._ddgSearchUrl %
                                    utils.web.urlquote_plus(text),
                                    headers=utils.web.defaultHeaders))
+        dym = page.find("div", id="did_you_mean")
+        if (dym):
+            return self._ddg(dym.find_all("a")[-1].text)
         results = page.find_all("div", class_="result__body")
         if len(results) == 1:
             return []

--- a/plugins/Internet/plugin.py
+++ b/plugins/Internet/plugin.py
@@ -546,6 +546,7 @@ class Internet(callbacks.Plugin):
                 "url": url,
                 "description": description.get_text(strip=True),
             })
+        return r
 
     @wrap(["text"])
     def ddg(self, irc, msg, args, text):

--- a/plugins/Internet/plugin.py
+++ b/plugins/Internet/plugin.py
@@ -527,6 +527,24 @@ class Internet(callbacks.Plugin):
         if title is not None:
             irc.reply(title)
 
+    _ddgSearchUrl = 'https://duckduckgo.com/html/?q=%s'
+    @wrap(["text"])
+    def ddg(self, irc, msg, args, text):
+        page = BS(utils.web.getUrl(self._ddgSearchUrl %
+                                   utils.web.urlquote_plus(text),
+                                   headers=utils.web.defaultHeaders))
+        result = page.find("div", {"class": "result__body"})
+        title = result.find("h2", {"class": "result__title"}).text.strip()
+        try:
+            url = title.find("a").attrs["href"]
+            url = utils.web.urlunquote(url[url.rfind("=")+1:])
+            description = result.find("a", {"class": "result__snippet"}).text
+        except Exception:
+            irc.reply("{}".format(title))   # Title will likely be a DuckDuckGo
+                                            # error like "No results."
+        else:
+            irc.reply('{} <{}>: {}'.format(title, url, description))
+
 Internet = internationalizeDocstring(Internet)
 
 Class = Internet


### PR DESCRIPTION
If you're looking for `sorcio` now ddg will look for `sorcio` instead of `socio` (auto-corrected)